### PR TITLE
make gen_sw_proposals format consistent with gen_proposal_list

### DIFF
--- a/ops/io.py
+++ b/ops/io.py
@@ -126,9 +126,9 @@ def dump_window_list(video_info, named_proposals, frame_path, name_pattern, allo
         overlap_self = pr[2]
         dump_proposals.append('{} {:.04f} {:.04f} {} {}'.format(label, overlap, overlap_self, real_start, real_end))
 
-    ret_str = '{path}\n{duration}\n{fps}\n{num_gt}\n{gts}\n{num_window}\n{prs}\n'.format(
+    ret_str = '{path}\n{duration}\n{fps}\n{num_gt}\n{gts}{num_window}\n{prs}\n'.format(
         path=os.path.join(frame_path, video_name), duration=frame_cnt, fps=1,
-        num_gt=len(dump_gt), gts='\n'.join(dump_gt),
+        num_gt=len(dump_gt), gts='\n'.join(dump_gt) + ('\n' if len(dump_gt) else ''),
         num_window=len(dump_proposals), prs='\n'.join(dump_proposals))
 
     return ret_str


### PR DESCRIPTION
gen_proposal_list.py uses function process_proposal_list() in io.py and gen_sliding_window_proposals.py uses function dump_window_list() in io.py to generate proposal files. However, these two functions have a slight difference when handling output formats. This pull request, along with the previous one, help to make the two formats consistent. Currently gen_sliding_window_proposals.py generates a redundant blank line when gt_num is 0.